### PR TITLE
add bottom margin

### DIFF
--- a/_extensions/youtube/youtube.lua
+++ b/_extensions/youtube/youtube.lua
@@ -2,7 +2,7 @@ function youtube(args)
     local videoid = pandoc.utils.stringify(args[1])
 
     -- Assemble HTML to be returned
-    local html = '<div id="youtube-frame" style="position: relative; padding-bottom: 56.25%; /* 16:9 */ height: 0;"><iframe width="100%" height="" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/'
+    local html = '<div id="youtube-frame" style="position: relative; padding-bottom: 56.25%; /* 16:9 */ height: 0; margin-bottom: 1rem;"><iframe width="100%" height="" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/'
         .. videoid
         .. '" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
 


### PR DESCRIPTION
This makes it more consistent with regular paragraphs, which also have `margin-bottom: 1rem;`.
Otherwise the next paragraph will be flush with the bottom of the video.